### PR TITLE
Fix a bug in config mode settings

### DIFF
--- a/arduino/combiLEDFirmware/combiLEDFirmware.ino
+++ b/arduino/combiLEDFirmware/combiLEDFirmware.ino
@@ -438,7 +438,7 @@ void getConfig() {
     clearInputString();
     waitForNewString();
     modDurMicroSecs = round(clockAdjustFactor * 1e6 * atof(inputString));
-    Serial.println(modDurMicroSecs);
+    Serial.println(atof(inputString));
   }
   if (strncmp(inputString, "CN", 2) == 0) {
     // fmContrast (0-1 float)
@@ -475,7 +475,7 @@ void getConfig() {
     waitForNewString();
     rampDurMicroSecs = round(clockAdjustFactor * 1e6 * atof(inputString));
     recip_rampDurMicroSecs = 1 / float(rampDurMicroSecs);
-    Serial.println(rampDurMicroSecs);
+    Serial.println(atof(inputString));
   }
   if (strncmp(inputString, "SD", 2) == 0) {
     // Start delay (float seconds)
@@ -483,7 +483,7 @@ void getConfig() {
     clearInputString();
     waitForNewString();
     startDelayMicroSecs = round(clockAdjustFactor * 1e6 * atof(inputString));
-    Serial.println(startDelayMicroSecs);
+    Serial.println(atof(inputString));
   }
   if (strncmp(inputString, "AM", 2) == 0) {
     // Amplitude modulation index
@@ -626,7 +626,7 @@ void getConfig() {
     clearInputString();
     waitForNewString();
     blinkDurMicroSecs = round(clockAdjustFactor * 1e6 * atof(inputString));
-    Serial.println(blinkDurMicroSecs);
+    Serial.println(atof(inputString));
   }
   if (strncmp(inputString, "CT", 2) == 0) {
     // Return arduino clock time in microseconds

--- a/code/@CombiLEDcontrol/setDuration.m
+++ b/code/@CombiLEDcontrol/setDuration.m
@@ -24,7 +24,7 @@ writeline(obj.serialObj,num2str(modulationDurSecs,'%.4f'));
 msg = readline(obj.serialObj);
 
 if obj.verbose
-    fprintf(['Modulation duration set to ' char(msg) ' microsecs\n']);
+    fprintf(['Modulation duration set to ' char(msg) ' seconds\n']);
 end
 
 

--- a/code/@CombiLEDcontrol/setRampDuration.m
+++ b/code/@CombiLEDcontrol/setRampDuration.m
@@ -24,7 +24,7 @@ writeline(obj.serialObj,num2str(rampDurSecs,'%.4f'));
 msg = readline(obj.serialObj);
 
 if obj.verbose
-    fprintf(['Ramp duration set to ' char(msg) ' microsecs\n']);
+    fprintf(['Ramp duration set to ' char(msg) ' seconds\n']);
 end
 
 

--- a/code/@CombiLEDcontrol/setStartDelay.m
+++ b/code/@CombiLEDcontrol/setStartDelay.m
@@ -24,7 +24,7 @@ writeline(obj.serialObj,num2str(startDelaySecs,'%.4f'));
 msg = readline(obj.serialObj);
 
 if obj.verbose
-    fprintf(['Start delay set to ' char(msg) ' microsecs\n']);
+    fprintf(['Start delay set to ' char(msg) ' seconds\n']);
 end
 
 


### PR DESCRIPTION
I was echoing back the passed settings in units of microseconds, which I think in some cases was causing the serial line write / read buffer to overflow